### PR TITLE
Default service account support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ go build -x -o $HOME/.ansible/plugins/modules/gcp_vault_secret .
 | parameter | required | default | choices | comments |
 |-----------|----------|---------|---------|----------|
 | name      | yes      | None    |         | Name of the secret in GCP Secret Manager |
-| creds_file | no      | /tmp/.ansible/gcp_vault_secret_creds.json    |    file path or "system"      | Path to Google API credentials file on remote filesystem | 
+| creds_file | no      | /tmp/.ansible/gcp_vault_secret_creds.json    |    file path or "system"      | Path to Google API credentials file on remote filesystem or use "system" if the default service account has permissions | 
 | project_id | no      | taken from creds_file, specify if "system" is used |         | Name of the GCP Project where Secret Manager resides |
 | private_google_api_endpoint      | no      | no    |    yes/no     | Make all requests to Google API via privately routed endpoint (private.googleapis.com:443) | 
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ go build -x -o $HOME/.ansible/plugins/modules/gcp_vault_secret .
 | parameter | required | default | choices | comments |
 |-----------|----------|---------|---------|----------|
 | name      | yes      | None    |         | Name of the secret in GCP Secret Manager |
-| creds_file | no      | /tmp/.ansible/gcp_vault_secret_creds.json    |   , file path or "system"      | Path to Google API credentials file on remote filesystem | 
+| creds_file | no      | /tmp/.ansible/gcp_vault_secret_creds.json    |    file path or "system"      | Path to Google API credentials file on remote filesystem | 
 | project_id | no      | taken from creds_file, specify if "system" is used |         | Name of the GCP Project where Secret Manager resides |
 | private_google_api_endpoint      | no      | no    |    yes/no     | Make all requests to Google API via privately routed endpoint (private.googleapis.com:443) | 
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ This is an example where the default service account on a system has read access
 ---
 - name: Test module gcp_vault_secret
   tasks:
-
   - name: Use default VM service account
     gcp_vault_secret:
       name: "my-secret-name"

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ go build -x -o $HOME/.ansible/plugins/modules/gcp_vault_secret .
 | parameter | required | default | choices | comments |
 |-----------|----------|---------|---------|----------|
 | name      | yes      | None    |         | Name of the secret in GCP Secret Manager |
-| creds_file | no      | /tmp/.ansible/gcp_vault_secret_creds.json    |         | Path to Google API credentials file on remote filesystem | 
-| project_id | no      | taken from creds_file |         | Name of the GCP Project where Secret Manager resides |
+| creds_file | no      | /tmp/.ansible/gcp_vault_secret_creds.json    |   , file path or "system"      | Path to Google API credentials file on remote filesystem | 
+| project_id | no      | taken from creds_file, specify if "system" is used |         | Name of the GCP Project where Secret Manager resides |
 | private_google_api_endpoint      | no      | no    |    yes/no     | Make all requests to Google API via privately routed endpoint (private.googleapis.com:443) | 
 
 
@@ -49,6 +49,19 @@ Example of usage in a playbook (for this example you will need to export `GOOGLE
         dest: /etc/pki/tls/private/ssl.key
 ```
 
+## System Example
+
+This is an example where the default service account on a system has read access to secret manager.
+```yaml
+--- 
+- name: Test System Service Account
+  gcp_vault_secret:
+    name: "my-secret-name"
+    private_google_api_endpoint: yes
+    creds_file: "system"
+    project_id: "gcp-project-name"
+  register: my_secret_value
+```
 ## Return Values
 
 | name | description | type | sample |

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ go build -x -o $HOME/.ansible/plugins/modules/gcp_vault_secret .
 
 Example of usage in a playbook (for this example you will need to export `GOOGLE_APPLICATION_CREDENTIALS` variable with local path to Google API creds file on your local host):
 ```yaml
+---
 - name: Test module gcp_vault_secret
   tasks:
     - name: Copy GCP credentials file to remote host
@@ -52,14 +53,22 @@ Example of usage in a playbook (for this example you will need to export `GOOGLE
 
 This is an example where the default service account on a system has read access to secret manager.
 ```yaml
---- 
-- name: Test System Service Account
-  gcp_vault_secret:
-    name: "my-secret-name"
-    private_google_api_endpoint: yes
-    creds_file: "system"
-    project_id: "gcp-project-name"
-  register: my_secret_value
+---
+- name: Test module gcp_vault_secret
+  tasks:
+
+  - name: Use default VM service account
+    gcp_vault_secret:
+      name: "my-secret-name"
+      private_google_api_endpoint: yes
+      creds_file: "system"
+      project_id: "gcp-project-name"
+    register: ssl_private_key
+
+  - name: Save secret key to disk
+    copy:
+      content: "{{ ssl_private_key.data }}\n"
+      dest: /etc/pki/tls/private/ssl.key
 ```
 ## Return Values
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ go build -x -o $HOME/.ansible/plugins/modules/gcp_vault_secret .
 
 Example of usage in a playbook (for this example you will need to export `GOOGLE_APPLICATION_CREDENTIALS` variable with local path to Google API creds file on your local host):
 ```yaml
----
 - name: Test module gcp_vault_secret
   tasks:
     - name: Copy GCP credentials file to remote host

--- a/build.txt
+++ b/build.txt
@@ -1,0 +1,1 @@
+GOOS=linux GOARCH=amd64 go build -x -o ./gcp_vault_secret .

--- a/process.go
+++ b/process.go
@@ -96,6 +96,14 @@ func produceResponse(ctx context.Context) *Response {
 		moduleArgs.CredentialsFile = defaultCredsPath
 	}
 
+	if moduleArgs.CredentialsFile == "system" {
+		moduleArgs.CredentialsFile = "system"
+	}
+
+	if moduleArgs.CredentialsFile == "system" && moduleArgs.ProjectID == "" {
+		return response.WithErrorf("Project ID is required when system is used for credentials.")
+	}
+
 	// If 'project_id' is empty, try using one from credentials file
 	if moduleArgs.ProjectID == "" {
 		// Read credentials file
@@ -118,10 +126,13 @@ func produceResponse(ctx context.Context) *Response {
 		}
 
 		moduleArgs.ProjectID = creds.ProjectID
+
 	}
 
 	// Set path to credentials file
-	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", moduleArgs.CredentialsFile)
+	if moduleArgs.CredentialsFile != "system" {
+		os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", moduleArgs.CredentialsFile)
+	}
 
 	// Create Google Secret Manager Client
 	client, err := NewGCPVaultClient(ctx, moduleArgs.ProjectID, moduleArgs.UsePrivateGoogleAPIEndpoint)


### PR DESCRIPTION
I had need to use a default service account that had read only permissions to GSM. I also had a requirement not to generate service account keys and ship credentials anywhere.

I updated the code to allow for a "system" level account that requires a project id be set as well.

This worked for my needs so I thought I would share. Appreciate any and all feedback!